### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,10 +25,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Login to Github Packages
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -36,7 +36,7 @@ jobs:
 
       - name: Docker metadata (tags, labels, etc)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: ghcr.io/chronicleprotocol/actions-runner-${{ matrix.app }}
           tags: |
@@ -50,18 +50,18 @@ jobs:
             type=sha
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
         with:
           platforms: all
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
         id: buildx
         with:
           install: true
 
       - name: Docker build and Push images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: ${{ matrix.app }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,7 +10,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - id: release
-        uses: rymndhng/release-on-push-action@master
+        uses: rymndhng/release-on-push-action@aebba2bbce07a9474bf95e8710e5ee8a9e922fe2
         with:
           bump_version_scheme: patch
           tag_prefix: v


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/docker.yml:28` `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5`
- `.github/workflows/docker.yml:31` `docker/login-action@v3` -> `docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9`
- `.github/workflows/docker.yml:39` `docker/metadata-action@v5` -> `docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051`
- `.github/workflows/docker.yml:53` `docker/setup-qemu-action@v3` -> `docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130`
- `.github/workflows/docker.yml:58` `docker/setup-buildx-action@v3` -> `docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f`
- `.github/workflows/docker.yml:64` `docker/build-push-action@v5` -> `docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25`
- `.github/workflows/tag-release.yml:13` `rymndhng/release-on-push-action@master` -> `rymndhng/release-on-push-action@aebba2bbce07a9474bf95e8710e5ee8a9e922fe2`